### PR TITLE
Fixes get_members decoding

### DIFF
--- a/lib/conversations_client.ex
+++ b/lib/conversations_client.ex
@@ -70,7 +70,7 @@ defmodule ExMicrosoftBot.Client.Conversations do
     end
 
     HTTPotion.get(api_endpoint, [headers: headers(TokenManager.get_token, api_endpoint)])
-    |> deserialize_response(&Models.ChannelAccount.parse/1) # TODO: Check if this works as it is an array
+    |> deserialize_response(&Models.ChannelAccount.parse/1)
   end
 
   @doc """

--- a/lib/models/channel_account.ex
+++ b/lib/models/channel_account.ex
@@ -24,7 +24,7 @@ defmodule ExMicrosoftBot.Models.ChannelAccount do
   """
   @spec parse(list) :: {:ok, [ExMicrosoftBot.Models.ChannelAccount.t]}
   def parse(param) when is_list(param) do
-    Poison.Decode.decode(param, as: decoding_array())
+    Poison.Decode.decode(param, as: [decoding_map()])
   end
 
   @doc """
@@ -33,11 +33,6 @@ defmodule ExMicrosoftBot.Models.ChannelAccount do
   @spec parse(String.t) :: ExMicrosoftBot.Models.ChannelAccount.t
   def parse(param) when is_binary(param) do
     parse Poison.decode!(param)
-  end
-
-  @doc false
-  def decoding_array() do
-    [decoding_map()]
   end
 
   @doc false

--- a/lib/models/channel_account.ex
+++ b/lib/models/channel_account.ex
@@ -16,7 +16,7 @@ defmodule ExMicrosoftBot.Models.ChannelAccount do
   """
   @spec parse(map) :: {:ok, ExMicrosoftBot.Models.ChannelAccount.t}
   def parse(param) when is_map(param) do
-    Poison.Decode.decode(param, as: decoding_map())
+    {:ok, Poison.Decode.decode(param, as: decoding_map())}
   end
 
   @doc """
@@ -24,7 +24,7 @@ defmodule ExMicrosoftBot.Models.ChannelAccount do
   """
   @spec parse(list) :: {:ok, [ExMicrosoftBot.Models.ChannelAccount.t]}
   def parse(param) when is_list(param) do
-    Poison.Decode.decode(param, as: [decoding_map()])
+    {:ok, Poison.Decode.decode(param, as: [decoding_map()])}
   end
 
   @doc """

--- a/lib/models/channel_account.ex
+++ b/lib/models/channel_account.ex
@@ -16,7 +16,15 @@ defmodule ExMicrosoftBot.Models.ChannelAccount do
   """
   @spec parse(map) :: {:ok, ExMicrosoftBot.Models.ChannelAccount.t}
   def parse(param) when is_map(param) do
-    {:ok, Poison.Decode.decode(param, as: decoding_map())}
+    Poison.Decode.decode(param, as: decoding_map())
+  end
+
+  @doc """
+  Decode a list of maps into a list of `ExMicrosoftBot.Models.ChannelAccount`
+  """
+  @spec parse(list) :: {:ok, [ExMicrosoftBot.Models.ChannelAccount.t]}
+  def parse(param) when is_list(param) do
+    Poison.Decode.decode(param, as: decoding_array())
   end
 
   @doc """
@@ -24,7 +32,12 @@ defmodule ExMicrosoftBot.Models.ChannelAccount do
   """
   @spec parse(String.t) :: ExMicrosoftBot.Models.ChannelAccount.t
   def parse(param) when is_binary(param) do
-    Poison.decode!(param, as: decoding_map())
+    parse Poison.decode!(param)
+  end
+
+  @doc false
+  def decoding_array() do
+    [decoding_map()]
   end
 
   @doc false

--- a/lib/models/channel_account.ex
+++ b/lib/models/channel_account.ex
@@ -32,7 +32,7 @@ defmodule ExMicrosoftBot.Models.ChannelAccount do
   """
   @spec parse(String.t) :: ExMicrosoftBot.Models.ChannelAccount.t
   def parse(param) when is_binary(param) do
-    parse Poison.decode!(param)
+    elem parse(Poison.decode!(param)), 1
   end
 
   @doc false

--- a/test/models/channel_acount_test.exs
+++ b/test/models/channel_acount_test.exs
@@ -1,0 +1,67 @@
+defmodule ExMicrosoftBot.Models.ChannelAcountTest do
+  use ExUnit.Case
+
+  alias ExMicrosoftBot.Models.ChannelAccount
+
+  describe ".parse/1" do
+    test "parses a map into the right struct" do
+      {:ok, %ChannelAccount{id: id, name: name}} = ChannelAccount.parse(%{
+        "id" => "123456789",
+        "name" => "Some Name"
+      })
+
+      assert id == "123456789"
+      assert name == "Some Name"
+    end
+
+    test "parses a list into an array of the right struct" do
+      {:ok, result} = ChannelAccount.parse([
+        %{
+          "id" => "123456789",
+          "name" => "Some Name"
+        },
+        %{
+          "id" => "987654321",
+          "name" => "Some Other Name"
+        }
+      ])
+
+      [
+        %ChannelAccount{id: id_a, name: name_a},
+        %ChannelAccount{id: id_b, name: name_b}
+      ] = result
+
+      assert id_a == "123456789"
+      assert name_a == "Some Name"
+
+      assert id_b == "987654321"
+      assert name_b == "Some Other Name"
+    end
+
+    test "parses a JSON encoded object" do
+      %ChannelAccount{id: id, name: name} =
+        ChannelAccount.parse("{\"id\":\"123456789\",\"name\":\"Some Name\"}")
+
+      assert id == "123456789"
+      assert name == "Some Name"
+    end
+
+    test "parses a JSON encoded array of objects" do
+      result = ChannelAccount.parse(
+        "[{\"id\":\"123456789\",\"name\":\"Some Name\"}," <>
+        "{\"id\":\"987654321\",\"name\":\"Some Other Name\"}]"
+      )
+
+      [
+        %ChannelAccount{id: id_a, name: name_a},
+        %ChannelAccount{id: id_b, name: name_b}
+      ] = result
+
+      assert id_a == "123456789"
+      assert name_a == "Some Name"
+
+      assert id_b == "987654321"
+      assert name_b == "Some Other Name"
+    end
+  end
+end


### PR DESCRIPTION
Getting members of a conversation returns an array of channel members which is
currently being parsed as a map, thereby failing. Also fixes the return of the
`parse` function, as it doesn't match the spec.