### PR TITLE
Accept all 200, Add conversationType

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -7,11 +7,11 @@ defmodule ExMicrosoftBot.Client do
 
   @type error_type :: {:error, integer, String.t()}
 
-  def deserialize_response(%HTTPotion.Response{status_code: 200, body: ""}, _deserialize_fn) do
+  def deserialize_response(%HTTPotion.Response{status_code: sc, body: ""}, _deserialize_fn) when sc >= 200 and sc < 300 do
     {:ok, ""}
   end
 
-  def deserialize_response(%HTTPotion.Response{status_code: 200, body: body}, deserialize_fn) do
+  def deserialize_response(%HTTPotion.Response{status_code: sc, body: body}, deserialize_fn) when sc >= 200 and sc < 300 do
     {:ok, deserialize_fn.(body)}
   end
 

--- a/lib/models/conversation_account.ex
+++ b/lib/models/conversation_account.ex
@@ -4,12 +4,13 @@ defmodule ExMicrosoftBot.Models.ConversationAccount do
   """
 
   @derive [Poison.Encoder]
-  defstruct [:isGroup, :id, :name]
+  defstruct [:isGroup, :id, :name, :conversationType]
 
   @type t :: %ExMicrosoftBot.Models.ConversationAccount{
     isGroup: boolean,
     id: String.t,
-    name: String.t
+    name: String.t,
+    conversationType: String.t
   }
 
   @doc false


### PR DESCRIPTION
`conversationType` docs: https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#conversationaccount-object

Adds tolerance to 2xx status codes. Sending a message, for example, returns 201, which the client is currently interpreting as an error.