### PR TITLE
Add missing fields to ConversationParameters

### DIFF
--- a/lib/conversations_client.ex
+++ b/lib/conversations_client.ex
@@ -9,7 +9,7 @@ defmodule ExMicrosoftBot.Client.Conversations do
   alias ExMicrosoftBot.TokenManager
 
   @doc """
-  Create a new Conversation. [API Reference](https://docs.botframework.com/en-us/restapi/connector/#!/Conversations/Conversations_CreateConversation)
+  Create a new Conversation. [API Reference](https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#conversation-object)
   """
   @spec create_conversation(String.t, Models.ConversationParameters.t) :: {:ok, Models.ResourceResponse.t} | Client.error_type
   def create_conversation(service_url, %Models.ConversationParameters{} = params) do

--- a/lib/models/conversation_parameters.ex
+++ b/lib/models/conversation_parameters.ex
@@ -4,13 +4,14 @@ defmodule ExMicrosoftBot.Models.ConversationParameters do
   """
 
   @derive [Poison.Encoder]
-  defstruct [:isGroup, :bot, :members, :topicName]
+  defstruct [:isGroup, :bot, :members, :topicName, :activity]
 
   @type t :: %ExMicrosoftBot.Models.ConversationParameters{
     isGroup: boolean,
     bot: ExMicrosoftBot.Models.ChannelAccount.t,
     members: [ExMicrosoftBot.Models.ChannelAccount.t],
-    topicName: String.t
+    topicName: String.t,
+    activity: ExMicrosoftBot.Models.Activity.t
   }
 
   @doc false

--- a/lib/models/conversation_parameters.ex
+++ b/lib/models/conversation_parameters.ex
@@ -4,14 +4,15 @@ defmodule ExMicrosoftBot.Models.ConversationParameters do
   """
 
   @derive [Poison.Encoder]
-  defstruct [:isGroup, :bot, :members, :topicName, :activity]
+  defstruct [:isGroup, :bot, :members, :topicName, :activity, :channelData]
 
   @type t :: %ExMicrosoftBot.Models.ConversationParameters{
     isGroup: boolean,
     bot: ExMicrosoftBot.Models.ChannelAccount.t,
     members: [ExMicrosoftBot.Models.ChannelAccount.t],
     topicName: String.t,
-    activity: ExMicrosoftBot.Models.Activity.t
+    activity: ExMicrosoftBot.Models.Activity.t,
+    channelData: map
   }
 
   @doc false


### PR DESCRIPTION
Bit of a weird one, this. The [API docs](https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#conversation-object) mention an `activity` object at the root level which, of course, includes `channelData`. However, if we try to create a conversation with just that we get:

```elixir
%HTTPotion.Response{body: "{\"error\":{\"code\":\"BadSyntax\",\"message\":\"Could not parse tenant id\"}}", headers: %HTTPotion.Headers{hdrs: %{"content-length" => "68", "content-type" => "application/json; charset=utf-8", "date" => "Thu, 02 May 2019 00:00:52 GMT", "server" => "Microsoft-HTTPAPI/2.0"}}, status_code: 400}
```

I dug around a bit and found the [Microsoft Teams docs](https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/bots/bot-conversations/bots-conv-proactive#example) for this endpoint, which includes the `channelData` in the top level. With this format, the request works.

The same format can be found in their [SDK](https://github.com/OfficeDev/BotBuilder-MicrosoftTeams/blob/7e078a611d727d27c1df81b33df9823e6b92ae64/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/ConnectorClientExtensions.cs#L60-L92).

I've opened an issue with the [docs repo](https://github.com/MicrosoftDocs/bot-docs/issues/1105), hopefully it'll get sorted.