### PR TITLE
Allows attachment content to be a string

### DIFF
--- a/lib/models/attachment.ex
+++ b/lib/models/attachment.ex
@@ -12,7 +12,7 @@ defmodule ExMicrosoftBot.Models.Attachment do
   @type t :: %ExMicrosoftBot.Models.Attachment{
     contentType: String.t,
     contentUrl: String.t,
-    content: map,
+    content: String.t | map,
     name: String.t,
     thumbnailUrl: String.t
   }
@@ -35,8 +35,6 @@ defmodule ExMicrosoftBot.Models.Attachment do
 
   @doc false
   def decoding_map() do
-    %ExMicrosoftBot.Models.Attachment {
-      content: %{}
-    }
+    %ExMicrosoftBot.Models.Attachment{}
   end
 end

--- a/lib/models/attachment.ex
+++ b/lib/models/attachment.ex
@@ -9,10 +9,13 @@ defmodule ExMicrosoftBot.Models.Attachment do
     :name, :thumbnailUrl
   ]
 
+  @type json_base_value :: String.t | number | boolean
+  @type json_object :: json_base_value  | [json_base_value] | %{optional(String.t) => json_object}
+
   @type t :: %ExMicrosoftBot.Models.Attachment{
     contentType: String.t,
     contentUrl: String.t,
-    content: String.t | map,
+    content: json_object,
     name: String.t,
     thumbnailUrl: String.t
   }

--- a/test/models/attachment_test.exs
+++ b/test/models/attachment_test.exs
@@ -1,0 +1,41 @@
+defmodule ExMicrosoftBot.Models.AttachmentTest do
+  use ExUnit.Case
+
+  alias ExMicrosoftBot.Models.Attachment
+
+  describe ".parse/1" do
+    test "parses a map with string content into the right types" do
+      {:ok, %Attachment{
+        contentType: contentType,
+        content: content,
+        name: name
+      }} = Attachment.parse(%{
+        "contentType" => "text/html",
+        "content" => "<div></div>",
+        "name" => "something"
+      })
+
+      assert contentType == "text/html"
+      assert content == "<div></div>"
+      assert name == "something"
+    end
+
+    test "parses a map with object content into the right types" do
+      {:ok, %Attachment{
+        contentType: contentType,
+        content: content,
+        name: name
+      }} = Attachment.parse(%{
+        "contentType" => "application/vnd.microsoft.card.hero",
+        "content" => %{
+          "subtitle" => "what a hero!"
+        },
+        "name" => "something else"
+      })
+
+      assert contentType == "application/vnd.microsoft.card.hero"
+      assert content == %{"subtitle" => "what a hero!"}
+      assert name == "something else"
+    end
+  end
+end

--- a/test/models/attachment_test.exs
+++ b/test/models/attachment_test.exs
@@ -28,13 +28,19 @@ defmodule ExMicrosoftBot.Models.AttachmentTest do
       }} = Attachment.parse(%{
         "contentType" => "application/vnd.microsoft.card.hero",
         "content" => %{
-          "subtitle" => "what a hero!"
+          "subtitle" => "what a hero!",
+          "how_much" => 42,
+          "really" => false
         },
         "name" => "something else"
       })
 
       assert contentType == "application/vnd.microsoft.card.hero"
-      assert content == %{"subtitle" => "what a hero!"}
+      assert content == %{
+        "subtitle" => "what a hero!",
+        "how_much" => 42,
+        "really" => false
+      }
       assert name == "something else"
     end
   end


### PR DESCRIPTION
When a message includes an emoji, for example, it's sent as an attachment, and the content will be a string of html. Example:

```elixir
%{
  "attachments" => [
    %{
      "contentType" => "image/*", 
      "contentUrl" => "https://statics.teams.microsoft.com/evergreen-assets/skype/v2/smile/50.png"
    }, 
    %{
      "content" => "<div><div><span class=\"animated-emoticon-50-smile\" title=\"Smiley\" type=\"(smile)\"><img itemid=\"smile\" itemscope=\"\" itemtype=\"http://schema.skype.com/Emoji\" src=\"https://statics.teams.microsoft.com/evergreen-assets/skype/v2/smile/50.png\" alt=\"≡ƒÿä\" style=\"width:50px; height:50px\"></span></div>\n</div>", 
      "contentType" => "text/html"
    }
  ]
  # ...
}
```