### PR TITLE
Adds `value` key to activity

### DIFF
--- a/lib/models/activity.ex
+++ b/lib/models/activity.ex
@@ -8,9 +8,11 @@ defmodule ExMicrosoftBot.Models.Activity do
     :type, :id, :timestamp, :serviceUrl, :channelId, :from, :conversation, :recipient, :textFormat,
     :attachmentLayout, :membersAdded, :membersRemoved, :topicName, :historyDisclosed, :locale,
     :text, :speak, :summary, :attachments, :entities, :suggestedActions, :channelData, :action, :replyToId,
-    :code, :inputHint
+    :code, :inputHint, :value
   ]
 
+  @type json_base_value :: String.t | number | boolean
+  @type json_object :: json_base_value  | [json_base_value] | %{optional(String.t) => json_object}
   @type t :: %ExMicrosoftBot.Models.Activity{
     type: String.t,
     id: String.t,
@@ -37,7 +39,8 @@ defmodule ExMicrosoftBot.Models.Activity do
     action: String.t,
     inputHint: String.t,
     code: String.t,
-    replyToId: String.t
+    replyToId: String.t,
+    value: json_object
   }
 
   @doc """

--- a/test/models/activity_test.exs
+++ b/test/models/activity_test.exs
@@ -30,7 +30,8 @@ defmodule ExMicrosoftBot.Models.ActivityTest do
         action: action,
         inputHint: inputHint,
         code: code,
-        replyToId: replyToId
+        replyToId: replyToId,
+        value: value
       }} = Activity.parse(%{
         "type" => "message",
         "id" => "1556500798576",
@@ -75,6 +76,10 @@ defmodule ExMicrosoftBot.Models.ActivityTest do
         "inputHint" => "hint hint",
         "code" => "42",
         "replyToId" => "123234345",
+        "value" => %{
+          "some_text" => "halp",
+          "some_number" => 42
+        }
       })
 
       assert type == "message"
@@ -129,6 +134,10 @@ defmodule ExMicrosoftBot.Models.ActivityTest do
       assert inputHint == "hint hint"
       assert code == "42"
       assert replyToId == "123234345"
+      assert value == %{
+        "some_text" => "halp",
+        "some_number" => 42
+      }
     end
 
     test "leaves out empty lists" do


### PR DESCRIPTION
As the title implies. When using a `button` of the type `messageBack` with Microsoft Teams, the response comes in the `value` key. For example:

```elixir
%{
  "channelData" => %{
    "source" => %{
      "name" => "message"
    }, 
    "tenant" => %{...}
  }, 
  "channelId" => "msteams", 
  "conversation" => %{
    "conversationType" => "personal", 
    "id" => "a:1AuvWS1e03HpEVfSxYrKCFR9d3ALV0D2GoRb-eEXHCccQHui7EHW_GXNFyGII80J2fL8WCJCkVoEbD2Af8ReCnh5MN7zWHGeDBjHPnXBt2P3pDpggYAzTbj25hF8DVHmK"
  }, 
  "entities" => [%{...}], 
  "from" => %{...}, 
  "id" => "f:4406681818723831069", 
  "localTimestamp" => "2019-10-11T16:03:37.775+01:00", 
  "locale" => "en-US", 
  "recipient" => %{...}, 
  "replyToId" => "1:1lhT4T9wXnknS9OxARSbLxGixArtHoomPzLoX8Q9lORs", 
  "serviceUrl" => "https://smba.trafficmanager.net/emea/", 
  "timestamp" => "2019-10-11T15:03:37.775Z", 
  "type" => "message", 
  "value" => %{
    "part_id" => 101, 
    "response" => "😱😱"
  }
}
```

In [docs](https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#activity-object) it's described as an "open-ended value", so I went ahead with all json types here.