### PR TITLE
Request auth token with application/x-www-form-urlencoded body

### DIFF
--- a/lib/token_manager.ex
+++ b/lib/token_manager.ex
@@ -110,25 +110,15 @@ defmodule ExMicrosoftBot.TokenManager do
 
     scope = Application.get_env(:ex_microsoftbot, :scope) || @scope
 
-    body =
-      convert_to_post_params_string(
-        # In testing the first param was not detected by the API hence adding a dummy param
-        dummy_param: "dummy",
-        grant_type: "client_credentials",
-        client_id: app_id,
-        client_secret: app_password,
-        scope: scope
-      )
+    body = URI.encode_query(%{
+      grant_type: "client_credentials",
+      client_id: app_id,
+      client_secret: app_password,
+      scope: scope
+    })
 
     auth_api_endpoint
-    |> HTTPotion.post(body: Poison.encode!(body))
+    |> HTTPotion.post(body: body, headers: ["Content-Type": "application/x-www-form-urlencoded"])
     |> Client.deserialize_response(&Poison.decode!(&1, as: %{}))
-  end
-
-  defp convert_to_post_params_string(params) do
-    params
-    |> Enum.reduce([], fn {k, v}, acc -> ["#{k}=#{URI.encode_www_form(v)}" | acc] end)
-    |> Enum.reverse()
-    |> Enum.join("&")
   end
 end


### PR DESCRIPTION
Out of the blue I started getting errors locally when grabbing the auth token. BotFramework would return that the scope element was invalid, printing it as `"https://api.botframework.com/.default///"`, those last 3 slashes presumably being the issue.

I went to check the code and saw that we were sending this as a JSON encoded URI encoded string? So I cleaned it up a bit to use `URI.encode_query/1` and set the right header as per [the docs](https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication?view=azure-bot-service-4.0#step-1-request-an-access-token-from-the-azure-ad-v2-account-login-service) and it's working again (even without the dummy arg).