### PR TITLE
Adds support for request timeout config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,33 +11,33 @@ API documentation is available at [https://hexdocs.pm/ex_microsofbot](https://he
 
 ## Installation
 
-  1. Add `ex_microsoftbot` to your list of dependencies in `mix.exs`:
+1. Add `ex_microsoftbot` to your list of dependencies in `mix.exs`:
 
-        ```elixir
-            def deps do
-              [{:ex_microsoftbot, "~> 2.0.2"}]
-            end
-        ```
+```elixir
+def deps do
+  [{:ex_microsoftbot, "~> 2.0.2"}]
+end
+```
 
-  2. Add the registered bot app id and app password in your config:
+2. Add the registered bot app id and app password in your config:
 
-        ```elixir
-            config :ex_microsoftbot,
-              app_id: "BOT_APP_ID",
-              app_password: "BOT_APP_PASSWORD"
-        ```
+```elixir
+config :ex_microsoftbot,
+  app_id: "BOT_APP_ID",
+  app_password: "BOT_APP_PASSWORD"
+```
 
-  3. Start the `ex_microsoftbot`:
+3. Start the `ex_microsoftbot`:
 
-        ```elixir
-            def application do
-              [applications: [:ex_microsoftbot]]
-            end
-        ```
+```elixir
+def application do
+  [applications: [:ex_microsoftbot]]
+end
+```
 
 ## Usage
 
-The modules `ExMicrosoftBot.Client.Attachments` and `ExMicrosoftBot.Client.Conversations` contain the functions to call the corresponding API of Microsoft Bot Framework. For example
+The modules `ExMicrosoftBot.Client.Attachments` and `ExMicrosoftBot.Client.Conversations` contain the functions to call the corresponding API of Microsoft Bot Framework. For example:
 
 ```elixir
 alias ExMicrosoftBot.Client.Conversations
@@ -63,3 +63,26 @@ def reply(activity = %Activity{}) do
   )
 end
 ```
+
+## Config
+
+In addition to the required auth configs mentioned in [Installation](#installation), there are a few more options available to customize this lib:
+
+```elixir
+config :ex_microsoftbot
+  using_bot_emulator: false,
+  scope: "https://api.botframework.com/.default",
+  http_timeout: nil
+```
+
+#### `using_bot_emulator`
+
+Default `false`. Set this to `true` to disable the auth token manager, and instead use a fake auth token in all requests.
+
+#### `scope`
+
+Default `"https://api.botframework.com/.default"`. This sets the scope used when authorizing with the BotFramework.
+
+#### `http_timeout`
+
+In milliseconds, defaults to the underlying lib (currently HTTPotion)'s default. Change this to set the timeout for each request to the Bot Framework.

--- a/lib/attachments_client.ex
+++ b/lib/attachments_client.ex
@@ -3,10 +3,9 @@ defmodule ExMicrosoftBot.Client.Attachments do
   This module provides the functions to get information related to attachments.
   """
 
-  import ExMicrosoftBot.Client, only: [headers: 2, deserialize_response: 2]
+  import ExMicrosoftBot.Client, only: [authed_req_options: 1, deserialize_response: 2]
   alias ExMicrosoftBot.Models, as: Models
   alias ExMicrosoftBot.Client
-  alias ExMicrosoftBot.TokenManager
 
   @doc """
   Get AttachmentInfo structure describing the attachment views. [API Reference](https://docs.botframework.com/en-us/restapi/connector/#!/Attachments/Attachments_GetAttachmentInfo)
@@ -15,7 +14,7 @@ defmodule ExMicrosoftBot.Client.Attachments do
   def get_attachment(service_url, attachment_id) do
     api_endpoint = "#{attachments_endpoint(service_url)}/#{attachment_id}"
 
-    HTTPotion.get(api_endpoint, [headers: headers(TokenManager.get_token, api_endpoint)])
+    HTTPotion.get(api_endpoint, authed_req_options(api_endpoint))
     |> deserialize_response(&Models.AttachmentInfo.parse/1)
   end
 
@@ -26,7 +25,7 @@ defmodule ExMicrosoftBot.Client.Attachments do
   def get_attachment_view(service_url, attachment_id, view_id) do
     api_endpoint = "#{attachments_endpoint(service_url)}/#{attachment_id}/views/#{view_id}"
 
-    HTTPotion.get(api_endpoint, [headers: headers(TokenManager.get_token, api_endpoint)])
+    HTTPotion.get(api_endpoint, authed_req_options(api_endpoint))
     |> deserialize_response(&(&1)) # Return the body as is because it is binary
   end
 

--- a/lib/conversations_client.ex
+++ b/lib/conversations_client.ex
@@ -3,10 +3,10 @@ defmodule ExMicrosoftBot.Client.Conversations do
   This module provides the functions for conversations
   """
 
-  import ExMicrosoftBot.Client, only: [headers: 2, deserialize_response: 2]
+  import ExMicrosoftBot.Client, only: [authed_req_options: 1, authed_req_options: 2, deserialize_response: 2]
+
   alias ExMicrosoftBot.Models, as: Models
   alias ExMicrosoftBot.Client
-  alias ExMicrosoftBot.TokenManager
 
   @doc """
   Create a new Conversation. [API Reference](https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#conversation-object)
@@ -16,7 +16,7 @@ defmodule ExMicrosoftBot.Client.Conversations do
 
     endpoint = conversations_endpoint(service_url)
 
-    HTTPotion.post(endpoint, [body: Poison.encode!(params), headers: headers(TokenManager.get_token, endpoint)])
+    HTTPotion.post(endpoint, authed_req_options(endpoint, body: Poison.encode!(params)))
     |> deserialize_response(&Models.ResourceResponse.parse/1)
   end
 
@@ -34,7 +34,7 @@ defmodule ExMicrosoftBot.Client.Conversations do
   def send_to_conversation(service_url, conversation_id, %Models.Activity{} = activity) do
     api_endpoint = "#{conversations_endpoint(service_url)}/#{conversation_id}/activities"
 
-    HTTPotion.post(api_endpoint, [body: Poison.encode!(activity), headers: headers(TokenManager.get_token, api_endpoint)])
+    HTTPotion.post(api_endpoint, authed_req_options(api_endpoint, body: Poison.encode!(activity)))
     |> deserialize_response(&(&1))
     |> change_deserialized_response_to_ok
   end
@@ -53,7 +53,7 @@ defmodule ExMicrosoftBot.Client.Conversations do
   def reply_to_activity(service_url, conversation_id, activity_id, %Models.Activity{} = activity) do
     api_endpoint = "#{conversations_endpoint(service_url)}/#{conversation_id}/activities/#{activity_id}"
 
-    HTTPotion.post(api_endpoint, [body: Poison.encode!(activity), headers: headers(TokenManager.get_token, api_endpoint)])
+    HTTPotion.post(api_endpoint, authed_req_options(api_endpoint, body: Poison.encode!(activity)))
     |> deserialize_response(&(&1))
     |> change_deserialized_response_to_ok
   end
@@ -69,7 +69,7 @@ defmodule ExMicrosoftBot.Client.Conversations do
       aid -> "#{conversations_endpoint(service_url)}/#{conversation_id}/activities/#{aid}/members"
     end
 
-    HTTPotion.get(api_endpoint, [headers: headers(TokenManager.get_token, api_endpoint)])
+    HTTPotion.get(api_endpoint, authed_req_options(api_endpoint))
     |> deserialize_response(&Models.ChannelAccount.parse/1)
   end
 
@@ -80,7 +80,7 @@ defmodule ExMicrosoftBot.Client.Conversations do
   def upload_attachment(service_url, conversation_id, %Models.AttachmentData{} = attachment) do
     api_endpoint = "#{conversations_endpoint(service_url)}/#{conversation_id}/attachments"
 
-    HTTPotion.post(api_endpoint, [body: Poison.encode!(attachment), headers: headers(TokenManager.get_token, api_endpoint)])
+    HTTPotion.post(api_endpoint, authed_req_options(api_endpoint, body: Poison.encode!(attachment)))
     |> deserialize_response(&Models.ResourceResponse.parse/1)
   end
 

--- a/lib/signing_keys_manager.ex
+++ b/lib/signing_keys_manager.ex
@@ -1,6 +1,7 @@
 defmodule ExMicrosoftBot.SigningKeysManager do
   use ExMicrosoftBot.RefreshableAgent
-  alias ExMicrosoftBot.Client
+
+  import ExMicrosoftBot.Client, only: [req_options: 0, deserialize_response: 2]
 
   # Public API
 
@@ -49,7 +50,7 @@ defmodule ExMicrosoftBot.SigningKeysManager do
 
   defp get_json_from_uri(uri) do
     uri
-    |> HTTPotion.get()
-    |> Client.deserialize_response(&Poison.decode!(&1, as: %{}))
+    |> HTTPotion.get(req_options())
+    |> deserialize_response(&Poison.decode!(&1, as: %{}))
   end
 end

--- a/lib/token_manager.ex
+++ b/lib/token_manager.ex
@@ -6,10 +6,11 @@ defmodule ExMicrosoftBot.TokenManager do
   """
 
   use ExMicrosoftBot.RefreshableAgent
+  import ExMicrosoftBot.Client, only: [req_options: 1]
   alias ExMicrosoftBot.{Client, Models}
 
   @auth_api_endpoint "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token"
-  @scope "https://api.botframework.com/.default"
+  @scope Application.get_env(:ex_microsoftbot, :scope, "https://api.botframework.com/.default")
 
   # Public API
 
@@ -108,17 +109,17 @@ defmodule ExMicrosoftBot.TokenManager do
     auth_api_endpoint =
       Application.get_env(:ex_microsoftbot, :auth_api_endpoint) || @auth_api_endpoint
 
-    scope = Application.get_env(:ex_microsoftbot, :scope) || @scope
-
     body = URI.encode_query(%{
       grant_type: "client_credentials",
       client_id: app_id,
       client_secret: app_password,
-      scope: scope
+      scope: @scope
     })
 
+    headers = ["Content-Type": "application/x-www-form-urlencoded"]
+
     auth_api_endpoint
-    |> HTTPotion.post(body: body, headers: ["Content-Type": "application/x-www-form-urlencoded"])
+    |> HTTPotion.post(req_options(body: body, headers: headers))
     |> Client.deserialize_response(&Poison.decode!(&1, as: %{}))
   end
 end


### PR DESCRIPTION
I'm getting frequent request timeouts in my app when sending messages, particularly to Slack, so need a way to increase the timeout value from the default of 5 seconds.

This PR exposes an `http_timeout` config option that is then passed on to all `HTTPotion` requests.

I've also cleaned up the README a bit and added some config options to it.