### PR TITLE
Add reactions fields to activity

### DIFF
--- a/lib/models/activity.ex
+++ b/lib/models/activity.ex
@@ -5,48 +5,76 @@ defmodule ExMicrosoftBot.Models.Activity do
 
   @derive [Poison.Encoder]
   defstruct [
-    :type, :id, :timestamp, :serviceUrl, :channelId, :from, :conversation, :recipient, :textFormat,
-    :attachmentLayout, :membersAdded, :membersRemoved, :topicName, :historyDisclosed, :locale,
-    :text, :speak, :summary, :attachments, :entities, :suggestedActions, :channelData, :action, :replyToId,
-    :code, :inputHint, :value
+    :type,
+    :id,
+    :timestamp,
+    :serviceUrl,
+    :channelId,
+    :from,
+    :conversation,
+    :recipient,
+    :textFormat,
+    :attachmentLayout,
+    :membersAdded,
+    :membersRemoved,
+    :reactionsAdded,
+    :reactionsRemoved,
+    :topicName,
+    :historyDisclosed,
+    :locale,
+    :text,
+    :speak,
+    :summary,
+    :attachments,
+    :entities,
+    :suggestedActions,
+    :channelData,
+    :action,
+    :replyToId,
+    :code,
+    :inputHint,
+    :value
   ]
 
-  @type json_base_value :: String.t | number | boolean
-  @type json_object :: json_base_value  | [json_base_value] | %{optional(String.t) => json_object}
+  @type json_base_value :: String.t() | number | boolean
+  @type json_object ::
+          json_base_value | [json_base_value] | %{optional(String.t()) => json_object}
   @type t :: %ExMicrosoftBot.Models.Activity{
-    type: String.t,
-    id: String.t,
-    timestamp: String.t,
-    serviceUrl: String.t,
-    channelId: String.t,
-    from: ExMicrosoftBot.Models.ChannelAccount.t,
-    conversation: ExMicrosoftBot.Models.ConversationAccount.t,
-    recipient: ExMicrosoftBot.Models.ChannelAccount.t,
-    textFormat: String.t,
-    attachmentLayout: String.t,
-    membersAdded: [ExMicrosoftBot.Models.ChannelAccount.t],
-    membersRemoved: [ExMicrosoftBot.Models.ChannelAccount.t],
-    topicName: String.t,
-    historyDisclosed: boolean,
-    locale: String.t,
-    text: String.t,
-    speak: String.t,
-    summary: String.t,
-    attachments: [ExMicrosoftBot.Models.Attachment.t],
-    entities: [ExMicrosoftBot.Models.Entity.t],
-    suggestedActions: [ExMicrosoftBot.Models.SuggestedAction.t],
-    channelData: map,
-    action: String.t,
-    inputHint: String.t,
-    code: String.t,
-    replyToId: String.t,
-    value: json_object
-  }
+          type: String.t(),
+          id: String.t(),
+          timestamp: String.t(),
+          serviceUrl: String.t(),
+          channelId: String.t(),
+          from: ExMicrosoftBot.Models.ChannelAccount.t(),
+          conversation: ExMicrosoftBot.Models.ConversationAccount.t(),
+          recipient: ExMicrosoftBot.Models.ChannelAccount.t(),
+          textFormat: String.t(),
+          attachmentLayout: String.t(),
+          membersAdded: [ExMicrosoftBot.Models.ChannelAccount.t()],
+          membersRemoved: [ExMicrosoftBot.Models.ChannelAccount.t()],
+          reactionsAdded: [ExMicrosoftbot.Models.Reaction.t()],
+          reactionsRemoved: [ExMicrosoftbot.Models.Reaction.t()],
+          topicName: String.t(),
+          historyDisclosed: boolean,
+          locale: String.t(),
+          text: String.t(),
+          speak: String.t(),
+          summary: String.t(),
+          attachments: [ExMicrosoftBot.Models.Attachment.t()],
+          entities: [ExMicrosoftBot.Models.Entity.t()],
+          suggestedActions: [ExMicrosoftBot.Models.SuggestedAction.t()],
+          channelData: map,
+          action: String.t(),
+          inputHint: String.t(),
+          code: String.t(),
+          replyToId: String.t(),
+          value: json_object
+        }
 
   @doc """
   Decode a map into `ExMicrosoftBot.Models.Activity`
   """
-  @spec parse(map) :: {:ok, ExMicrosoftBot.Models.Activity.t}
+  @spec parse(map) :: {:ok, ExMicrosoftBot.Models.Activity.t()}
   def parse(param) when is_map(param) do
     {:ok, Poison.Decode.transform(param, %{as: decoding_map()})}
   end
@@ -54,19 +82,21 @@ defmodule ExMicrosoftBot.Models.Activity do
   @doc """
   Decode a string into `ExMicrosoftBot.Models.Activity`
   """
-  @spec parse(String.t) :: ExMicrosoftBot.Models.Activity.t
+  @spec parse(String.t()) :: ExMicrosoftBot.Models.Activity.t()
   def parse(param) when is_binary(param) do
     Poison.decode!(param, as: decoding_map())
   end
 
   @doc false
   def decoding_map() do
-    %ExMicrosoftBot.Models.Activity {
+    %ExMicrosoftBot.Models.Activity{
       from: ExMicrosoftBot.Models.ChannelAccount.decoding_map(),
       conversation: ExMicrosoftBot.Models.ConversationAccount.decoding_map(),
       recipient: ExMicrosoftBot.Models.ChannelAccount.decoding_map(),
       membersAdded: [ExMicrosoftBot.Models.ChannelAccount.decoding_map()],
       membersRemoved: [ExMicrosoftBot.Models.ChannelAccount.decoding_map()],
+      reactionsAdded: [ExMicrosoftBot.Models.Reaction.decoding_map()],
+      reactionsRemoved: [ExMicrosoftBot.Models.Reaction.decoding_map()],
       attachments: [ExMicrosoftBot.Models.Attachment.decoding_map()],
       entities: [ExMicrosoftBot.Models.Entity.decoding_map()],
       suggestedActions: [ExMicrosoftBot.Models.SuggestedAction.decoding_map()],

--- a/lib/models/reaction.ex
+++ b/lib/models/reaction.ex
@@ -1,0 +1,41 @@
+defmodule ExMicrosoftBot.Models.Reaction do
+  @moduledoc """
+  Microsoft bot structure which corresponds to a Reaction on a message
+  """
+
+  @derive [Poison.Encoder]
+  defstruct [:type]
+
+  @type t :: %ExMicrosoftBot.Models.Reaction{
+          type: String.t()
+        }
+
+  @doc """
+  Decode a map into `ExMicrosoftBot.Models.Reaction`
+  """
+  @spec parse(map) :: {:ok, ExMicrosoftBot.Models.Reaction.t()}
+  def parse(param) when is_map(param) do
+    {:ok, Poison.Decode.transform(param, %{as: decoding_map()})}
+  end
+
+  @doc """
+  Decode a list of maps into a list of `ExMicrosoftBot.Models.Reaction`
+  """
+  @spec parse(list) :: {:ok, [ExMicrosoftBot.Models.Reaction.t()]}
+  def parse(param) when is_list(param) do
+    {:ok, Poison.Decode.transform(param, %{as: [decoding_map()]})}
+  end
+
+  @doc """
+  Decode a string into `ExMicrosoftBot.Models.Reaction`
+  """
+  @spec parse(String.t()) :: ExMicrosoftBot.Models.Reaction.t()
+  def parse(param) when is_binary(param) do
+    elem(parse(Poison.decode!(param)), 1)
+  end
+
+  @doc false
+  def decoding_map() do
+    %ExMicrosoftBot.Models.Reaction{}
+  end
+end

--- a/test/models/activity_test.exs
+++ b/test/models/activity_test.exs
@@ -19,6 +19,8 @@ defmodule ExMicrosoftBot.Models.ActivityTest do
          attachmentLayout: attachmentLayout,
          membersAdded: membersAdded,
          membersRemoved: membersRemoved,
+         reactionsAdded: reactionsAdded,
+         reactionsRemoved: reactionsRemoved,
          topicName: topicName,
          historyDisclosed: historyDisclosed,
          locale: locale,
@@ -52,6 +54,8 @@ defmodule ExMicrosoftBot.Models.ActivityTest do
           "attachmentLayout" => "flat",
           "membersAdded" => [%{"id" => "someother:id", "name" => "Some Other Name"}],
           "membersRemoved" => [%{"id" => "some:id", "name" => "Some Name"}],
+          "reactionsAdded" => [%{"type" => "heart"}],
+          "reactionsRemoved" => [%{"type" => "heart"}],
           "topicName" => "Potatoes",
           "historyDisclosed" => false,
           "locale" => "en-US",
@@ -128,6 +132,18 @@ defmodule ExMicrosoftBot.Models.ActivityTest do
                }
              ]
 
+      assert reactionsAdded == [
+               %ExMicrosoftBot.Models.Reaction{
+                 type: "heart"
+               }
+             ]
+
+      assert reactionsRemoved == [
+               %ExMicrosoftBot.Models.Reaction{
+                 type: "heart"
+               }
+             ]
+
       assert topicName == "Potatoes"
       assert historyDisclosed == false
       assert locale == "en-US"
@@ -174,6 +190,8 @@ defmodule ExMicrosoftBot.Models.ActivityTest do
        %Activity{
          membersAdded: membersAdded,
          membersRemoved: membersRemoved,
+         reactionsAdded: reactionsAdded,
+         reactionsRemoved: reactionsRemoved,
          attachments: attachments,
          entities: entities,
          suggestedActions: suggestedActions
@@ -181,6 +199,8 @@ defmodule ExMicrosoftBot.Models.ActivityTest do
 
       assert membersAdded == nil
       assert membersRemoved == nil
+      assert reactionsAdded == nil
+      assert reactionsRemoved == nil
       assert attachments == nil
       assert entities == nil
       assert suggestedActions == nil


### PR DESCRIPTION
Couldn't find docs for this, but here's a sample request (in prod):

```json
{
  "replyToId":"abcd",
  "from":{
    "aadObjectId":"...",
    "id":"..."
  },
  "timestamp":"2020-11-24T09:15:15.6739656Z",
  "channelId":"msteams",
  "reactionsAdded":[
    {
      "type":"heart"
    }
  ],
  "conversation":{
    "tenantId":"...",
    "conversationType":"personal",
    "id":"..."
  },
  "serviceUrl":"https://smba.trafficmanager.net/emea/",
  "type":"messageReaction",
  "channelData":{
    "legacy":{
      "replyToId":"..."
    },
    "tenant":{
      "id":"..."
    }
  },
  "recipient":{
    "id":"...",
    "name":"Skoach"
  },
  "id":"..."
}
```