### PR TITLE
Adds support for fetching members using pagination

### DIFF
--- a/lib/models/paged_members_result.ex
+++ b/lib/models/paged_members_result.ex
@@ -1,0 +1,37 @@
+defmodule ExMicrosoftBot.Models.PagedMembersResult do
+  @moduledoc """
+  BotFramework structure for returning paginated conversation member data.
+  @see [API Reference](https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#pagedmembersresult-object)
+  """
+
+  @derive [Poison.Encoder]
+  defstruct [:members, :continuationToken]
+
+  @type t :: %__MODULE__{
+          members: [ExMicrosoftBot.Models.ChannelAccount.t()],
+          continuationToken: String.t() | nil
+        }
+
+  @doc """
+  Decodes a map into `ExMicrosoftBot.Models.PagedMembersResult`
+  """
+  @spec parse(map :: map()) :: {:ok, __MODULE__.t()}
+  def parse(map) when is_map(map) do
+    {:ok, Poison.Decode.transform(map, %{as: decoding_map()})}
+  end
+
+  @doc """
+  Decodes a JSON string into `ExMicrosoftBot.Models.PagedMembersResult`
+  """
+  @spec parse(json :: String.t()) :: __MODULE__.t()
+  def parse(json) when is_binary(json) do
+    elem(parse(Poison.decode!(json)), 1)
+  end
+
+  @doc false
+  def decoding_map() do
+    %__MODULE__{
+      members: [ExMicrosoftBot.Models.ChannelAccount.decoding_map()]
+    }
+  end
+end


### PR DESCRIPTION
I wasn't able to _actually_ test this request with pagination because (I think?) I don't have a large enough team... but the endpoint does work, even if it only returned a list of all members, regardless of the `page_size` param.