### PR TITLE
Adds tenantId to ConversationParams

### DIFF
--- a/lib/models/conversation_parameters.ex
+++ b/lib/models/conversation_parameters.ex
@@ -4,16 +4,17 @@ defmodule ExMicrosoftBot.Models.ConversationParameters do
   """
 
   @derive [Poison.Encoder]
-  defstruct [:isGroup, :bot, :members, :topicName, :activity, :channelData]
+  defstruct [:activity, :bot, :channelData, :isGroup, :members, :tenantId, :topicName]
 
   @type t :: %ExMicrosoftBot.Models.ConversationParameters{
-    isGroup: boolean,
-    bot: ExMicrosoftBot.Models.ChannelAccount.t,
-    members: [ExMicrosoftBot.Models.ChannelAccount.t],
-    topicName: String.t,
-    activity: ExMicrosoftBot.Models.Activity.t,
-    channelData: map
-  }
+          activity: ExMicrosoftBot.Models.Activity.t(),
+          bot: ExMicrosoftBot.Models.ChannelAccount.t(),
+          channelData: map,
+          isGroup: boolean,
+          members: [ExMicrosoftBot.Models.ChannelAccount.t()],
+          tenantId: String.t(),
+          topicName: String.t()
+        }
 
   @doc false
   def decoding_map() do


### PR DESCRIPTION
Docs: https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#conversationparameters-object